### PR TITLE
Prevent Image Download

### DIFF
--- a/components/HeroGallery.tsx
+++ b/components/HeroGallery.tsx
@@ -9,6 +9,10 @@ interface HeroGalleryProps {
   handleModal : (isOpening : boolean, folder: string | null) => void;
 }
 
+const preventRightClick = (e : React.MouseEvent) => {
+  e.preventDefault();
+}
+
 const HeroGallery : React.FC<HeroGalleryProps> = ({ columns, handleModal }) => {
   return (
     <div className={styles.galleryContainer}>
@@ -19,6 +23,7 @@ const HeroGallery : React.FC<HeroGalleryProps> = ({ columns, handleModal }) => {
               <motion.div whileHover={{ scale: 1.02 }} transition={{ duration: 0.3 }}>
                 <AdvancedImage
                   onClick={() => handleModal(true, photo.folder)}
+                  onContextMenu= {preventRightClick}
                   cldImg={photo.image}
                   className="advanced-image"
                   style={{ width: '100%', borderRadius: '4px' }}

--- a/components/gallery/horizontalScrollGallery.tsx
+++ b/components/gallery/horizontalScrollGallery.tsx
@@ -65,6 +65,10 @@ const HorizontalGallery : React.FC<HorizontalGalleryProps> = ( {public_id}) => {
     };
 }, []);
 
+const preventRightClick = (e : React.MouseEvent) => {
+  e.preventDefault();
+}
+
   return  (
     <>
       <div style={{ overflowY: 'hidden', overflowX: 'scroll', height: '100dvh'}} id="scroll-container">
@@ -75,7 +79,7 @@ const HorizontalGallery : React.FC<HorizontalGalleryProps> = ( {public_id}) => {
               {photos.map((photo, index) => (
                 <motion.div whileHover={{ scale: 1.1 }} transition={{ duration: 0.3 }} style={{placeContent: 'center'}}>
                   <div className={styles.thumbnail} key={index}>
-                    <AdvancedImage cldImg={photo} style={{ maxHeight: '70vh', maxWidth: '70vw' }} />
+                    <AdvancedImage cldImg={photo} style={{ maxHeight: '70vh', maxWidth: '70vw' }} onContextMenu={preventRightClick} />
                   </div>
                 </motion.div>
               ))}


### PR DESCRIPTION
Found a pretty simple solution to preventing right click image downloads by disabling the context menu from opening if you right click a photo. 
Unfortunately it seems that there's no perfect way to prevent somebody who is sorta good at browser dev tools from downloading an image off this site, but I think this will keep Kenny and Cian happy.
Additionally if we wanted to down the road, we could try to add some copyright info to the exif data, which would make it easier to have those images taken down if they're used anywhere else, but I don't know if it's that high of a priority for us.  
