### PR TITLE
horizontal gallery - fix glitchy loading, add some simple animation

### DIFF
--- a/components/gallery/horizontalScrollGallery.tsx
+++ b/components/gallery/horizontalScrollGallery.tsx
@@ -73,11 +73,29 @@ const preventRightClick = (e : React.MouseEvent) => {
     <>
       <div style={{ overflowY: 'hidden', overflowX: 'scroll', height: '100dvh'}} id="scroll-container">
         <PageTransition>
-          <motion.section className={styles.thumbnailscontainer}>
+          {/* adding this motion.section seemed to help with glitchy loading */}
+          <motion.section className={styles.thumbnailscontainer}
+          initial="hidden"  
+          animate="show"
+          variants={{
+            hidden: {opacity : 0},
+            show: {
+              opacity: 1,
+              transition: {
+                staggerChildren: .3  //delay between children loading
+              }
+            }
+          }}>
 
             <div className={styles.thumbnails}>
               {photos.map((photo, index) => (
-                <motion.div whileHover={{ scale: 1.1 }} transition={{ duration: 0.3 }} style={{placeContent: 'center'}}>
+                <motion.div 
+                  key={index}
+                  initial={{ opacity: 0, x: -10 }} // start invisible, slide in from left
+                  animate={{ opacity: 1, x: 0 }} // final opacity to 1, slide into final x position
+                  transition={{ duration: 0.5, delay: index * 0.1 }} // duration: speed of opacity 0 -> 100, delay: speed of sequential image rendering
+                  // whileHover={{ scale: 1.1 }}  
+                  style={{placeContent: 'center'}}>
                   <div className={styles.thumbnail} key={index}>
                     <AdvancedImage cldImg={photo} style={{ maxHeight: '70vh', maxWidth: '70vw' }} onContextMenu={preventRightClick} />
                   </div>


### PR DESCRIPTION
I used some framer motion stuff to make the horizontal gallery look a little smoother when loading in. In all my testing, didn't notice the glitchy looking loading issue that would happen every once in a while on the first load of a gallery. 

Also added in some simple animation. Opacity going from 0 -> 100 sequentially for each image in the gallery, and slight in each image from the left a lil bit. 

Might not be the feel they want, but left some comments about what each value does so it should be easy for us to dial in the feel. 