### PR TITLE
New Modal Pages Infrastructure

### DIFF
--- a/components/HeroGallery.tsx
+++ b/components/HeroGallery.tsx
@@ -17,7 +17,10 @@ const preventRightClick = (e : React.MouseEvent) => {
 
 const HeroGallery : React.FC<HeroGalleryProps> = ({ columns, handleModal }) => {
 
+
   const { openModal } = useModal();
+
+
   return (
     <div className={styles.galleryContainer}>
       {columns.map((column, columnIndex) => (
@@ -35,7 +38,7 @@ const HeroGallery : React.FC<HeroGalleryProps> = ({ columns, handleModal }) => {
                   className={styles.imageWrapper}>
 
                   <AdvancedImage
-                    onClick={() => handleModal(true, photo.folder)}
+                    onClick={() => openModal('gallery', photo.folder)}
                     onContextMenu={preventRightClick}
                     cldImg={photo.image}
                     className={styles.advancedImage}

--- a/components/HeroGallery.tsx
+++ b/components/HeroGallery.tsx
@@ -4,6 +4,7 @@ import { AdvancedImage } from '@cloudinary/react'; // Adjust according to how yo
 import styles from '../styles/HeroGallery.module.css'; // Import CSS module
 import { Photo } from '../types/types';
 import ScrollIndicator from './common/ScrollIndicator';
+import { useModal } from '../context/ModalContext';
 
 interface HeroGalleryProps {
   columns: Photo[][],
@@ -15,6 +16,8 @@ const preventRightClick = (e : React.MouseEvent) => {
 }
 
 const HeroGallery : React.FC<HeroGalleryProps> = ({ columns, handleModal }) => {
+
+  const { openModal } = useModal();
   return (
     <div className={styles.galleryContainer}>
       {columns.map((column, columnIndex) => (

--- a/components/HeroGallery.tsx
+++ b/components/HeroGallery.tsx
@@ -8,14 +8,13 @@ import { useModal } from '../context/ModalContext';
 
 interface HeroGalleryProps {
   columns: Photo[][],
-  handleModal : (isOpening : boolean, folder: string | null) => void;
 }
 
 const preventRightClick = (e : React.MouseEvent) => {
   e.preventDefault();
 }
 
-const HeroGallery : React.FC<HeroGalleryProps> = ({ columns, handleModal }) => {
+const HeroGallery : React.FC<HeroGalleryProps> = ({ columns }) => {
 
 
   const { openModal } = useModal();

--- a/components/common/ScrollIndicator.tsx
+++ b/components/common/ScrollIndicator.tsx
@@ -1,6 +1,8 @@
 import { motion, MotionValue } from "framer-motion";
 import React, { useEffect, useRef, useState } from "react";
 import styles from "../../styles/ScrollIndicator.module.css";
+import { useModal } from "../../context/ModalContext";
+import Footer from "./footerbutton";
 
 interface ScrollIndicatorProps {
   scrollXProgress?: MotionValue<number>;
@@ -8,6 +10,7 @@ interface ScrollIndicatorProps {
 
 const ScrollIndicator: React.FC<ScrollIndicatorProps> = ({ scrollXProgress }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const { closeModal } = useModal();
 
   const [clipPaths, setClipPaths] = useState({
     base: "inset(0 100% 0 0)",
@@ -58,6 +61,10 @@ const ScrollIndicator: React.FC<ScrollIndicatorProps> = ({ scrollXProgress }) =>
       <div className={styles.bottomLeftBase}>INDEX</div>
       <div className={styles.bottomCenterBase}>PRODUCTION</div>
       <div className={styles.bottomRightBase}>CLOVER</div>
+
+      {/* Invisible overlay button */}
+      <button className={styles.invisibleButton} onClick={() => {closeModal()}} />
+      <Footer />
     </div>
   );
 };

--- a/components/common/footerbutton.tsx
+++ b/components/common/footerbutton.tsx
@@ -1,9 +1,8 @@
-import styles from '../../styles/Home.module.css';
+import styles from '../../styles/Footer.module.css';
 import { Menu, MenuItem } from "./Menu";
-import Link from 'next/link';
 import { useState } from "react";
 import type { MotionProps, Variants } from "framer-motion";
-import Image from 'next/image';
+import { useModal } from '../../context/ModalContext';
 
 const menu = {
   closed: {
@@ -35,12 +34,13 @@ const item = {
 export default function Footer() {
 
   const [open1, setOpen] = useState(false);
+  const { openModal } = useModal();
 
   return (
     <div className={styles.footer}>
       <Menu
         label={
-          <div style={{ position: 'relative', width: '100px', height: '100px', opacity: 0 }}> 
+          <div style={{ position: 'relative', width: '100px', height: '100px', opacity: 0, cursor: 'pointer' }}> 
           CLOVER
           </div>
         }
@@ -51,14 +51,10 @@ export default function Footer() {
         exit="closed"
         variants={menu}
       >
-        <MenuItem {...item} className={styles.menuitem} onClick={() => setOpen(false)}>
-          <Link href="/"> INDEX </Link>
-        </MenuItem>
 
         <MenuItem {...item} className={styles.menuitem}>SHOP</MenuItem>
-        <MenuItem {...item} className={styles.menuitem}>COFFEE</MenuItem>
-        <MenuItem {...item} className={styles.menuitem}>ABOUT</MenuItem>
-        <MenuItem {...item} className={styles.menuitem}>CONTACT</MenuItem>
+        <MenuItem {...item} className={styles.menuitem} onClick={() => {setOpen(false); openModal('coffee', null);}}>COFFEE</MenuItem>
+        <MenuItem {...item} className={styles.menuitem} onClick={() => {setOpen(false); openModal('about', null);}}>INFO/CONTACT</MenuItem>
       </Menu>
     </div>
   );

--- a/components/common/footerbutton.tsx
+++ b/components/common/footerbutton.tsx
@@ -40,7 +40,7 @@ export default function Footer() {
     <div className={styles.footer}>
       <Menu
         label={
-          <div style={{ position: 'relative', width: '100px', height: '100px' }}>
+          <div style={{ position: 'relative', width: '100px', height: '100px', opacity: 0 }}> 
           CLOVER
           </div>
         }

--- a/components/gallery/ModalGallery.tsx
+++ b/components/gallery/ModalGallery.tsx
@@ -1,7 +1,7 @@
 import ReactDOM from "react-dom";
 import HorizontalGallery from "./horizontalScrollGallery";
 import styles from "../../styles/Modal.module.css"
-import { useModal } from '../../context/ModalContext';
+import ScrollIndicator from "../common/ScrollIndicator";
 
 interface ModalProps {
     onClose : Function,
@@ -13,7 +13,7 @@ const Modal : React.FC<ModalProps> = ({ onClose, public_id, state }) => {
     const handleCloseClick = (e : React.MouseEvent<HTMLAnchorElement>) => {
         // reset public id on close
         console.log("handling close click")
-        public_id = null;
+        public_id = null; // I don't think we need this
         e.preventDefault();
         onClose();
     };
@@ -34,12 +34,16 @@ const Modal : React.FC<ModalProps> = ({ onClose, public_id, state }) => {
                         )}
                         {
                             (state === 'about') && (
-                                <div>About</div>
+                                <div>About
+                                <ScrollIndicator/>
+                                </div>
                             )
                         }
                            {
                             (state === 'coffee') && (
-                                <div>About</div>
+                                <div>Coffee
+                                    <ScrollIndicator/>
+                                </div>
                             )
                         }
                         

--- a/components/gallery/ModalGallery.tsx
+++ b/components/gallery/ModalGallery.tsx
@@ -1,13 +1,15 @@
-import React from "react";
 import ReactDOM from "react-dom";
 import HorizontalGallery from "./horizontalScrollGallery";
+import styles from "../../styles/Modal.module.css"
+import { useModal } from '../../context/ModalContext';
 
 interface ModalProps {
     onClose : Function,
     public_id : string | null,
+    state : string | null,
 }
 
-const Modal : React.FC<ModalProps> = ({ onClose, public_id }) => {
+const Modal : React.FC<ModalProps> = ({ onClose, public_id, state }) => {
     const handleCloseClick = (e : React.MouseEvent<HTMLAnchorElement>) => {
         // reset public id on close
         console.log("handling close click")
@@ -17,16 +19,30 @@ const Modal : React.FC<ModalProps> = ({ onClose, public_id }) => {
     };
 
     const modalContent = (
-        <div className="modal-overlay">
+        <div className={styles.modalOverlay}>
             {/* Wrap the whole Modal inside the newly created StyledModalWrapper
             and use the ref */}
-            <div className="modal-wrapper" >
-                <div className="modal" >
+            <div className={styles.modalWrapper} >
+                <div className={styles.modal} >
                     <a style={{position: "absolute", top: 10, right: 10, fontSize: 32, width: 32, height: 32, zIndex: 25}} href="#" onClick={handleCloseClick}>
                         x
                     </a>
-                    <div className="modal-body" >
-                        <HorizontalGallery public_id={public_id}  />
+                    <div className={styles.modalBody} >
+                        {
+                            (state === 'gallery') && (
+                                <HorizontalGallery public_id={public_id}  />
+                        )}
+                        {
+                            (state === 'about') && (
+                                <div>About</div>
+                            )
+                        }
+                           {
+                            (state === 'coffee') && (
+                                <div>About</div>
+                            )
+                        }
+                        
                     </div>
                 </div>
             </div>

--- a/components/gallery/horizontalScrollGallery.tsx
+++ b/components/gallery/horizontalScrollGallery.tsx
@@ -140,7 +140,6 @@ const HorizontalGallery : React.FC<HorizontalGalleryProps> = ( {public_id}) => {
 
         </PageTransition>
       </div>
-      <Footer />
     </>
   );
 

--- a/components/gallery/horizontalScrollGallery.tsx
+++ b/components/gallery/horizontalScrollGallery.tsx
@@ -44,10 +44,9 @@ const HorizontalGallery : React.FC<HorizontalGalleryProps> = ( {public_id}) => {
     );
 
   useEffect(() => {
-
     if (typeof public_id !== 'string') return;
     const folder = public_id;
-    console.log(folder)
+    console.log(`folder name: ${folder}`)
     fetch(`/api/projectphotos?folder=${folder}`)
       .then(response => response.json())
       .then(data => {

--- a/context/ModalContext.tsx
+++ b/context/ModalContext.tsx
@@ -34,7 +34,7 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({ children }) => {
         setShowModal(true);
 
         // TODO: change this to push arguments to url instead of page-like stuff
-        if (state === 'about') {
+        if (state === 'about' || state === 'coffee') {
             //router.push("/about", undefined, { shallow: true });
             router.push(`/?page=${state}`, undefined, {shallow: true});
         } else if (state === 'gallery' && id) {

--- a/context/ModalContext.tsx
+++ b/context/ModalContext.tsx
@@ -1,0 +1,66 @@
+// ModalContext.tsx
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { useRouter } from 'next/router';
+
+// Define the shape of the context
+interface ModalContextType {
+    showModal: boolean;
+    modalState: string;
+    public_id: string | null;
+    openModal: (state: string, id: string | null) => void;
+    closeModal: () => void;
+}
+
+// Create the context with a default value of undefined
+const ModalContext = createContext<ModalContextType | undefined>(undefined);
+
+// Props for the provider
+interface ModalProviderProps {
+    children: ReactNode;
+}
+
+// ModalProvider component
+export const ModalProvider: React.FC<ModalProviderProps> = ({ children }) => {
+    const router = useRouter();
+    const [showModal, setShowModal] = useState<boolean>(false);
+    const [modalState, setModalState] = useState<string>('');
+    const [public_id, setPublicId] = useState<string | null>(null);
+
+    // Function to open a modal with specific state and public_id
+    const openModal = (state: string, id: string | null) => {
+        
+        setModalState(state);
+        setPublicId(id);
+        setShowModal(true);
+        
+        // TODO: change this to push arguments to url instead of page-like stuff
+        if (state === 'about') {
+            router.push("/about", undefined, { shallow: true });
+        } else if (state === 'gallery' && id) {
+            router.push(`/gallery/${id}`, undefined, { shallow: true });
+        }
+    };
+
+    // Function to close the modal
+    const closeModal = () => {
+        setShowModal(false);
+        setModalState('');
+        setPublicId(null);
+        router.push("/", undefined, { shallow: true });
+    };
+
+    return (
+        <ModalContext.Provider value={{ showModal, modalState, public_id, openModal, closeModal }}>
+            {children}
+        </ModalContext.Provider>
+    );
+};
+
+// Custom hook for easier access to modal context
+export const useModal = (): ModalContextType => {
+    const context = useContext(ModalContext);
+    if (!context) {
+        throw new Error("useModal must be used within a ModalProvider");
+    }
+    return context;
+};

--- a/context/ModalContext.tsx
+++ b/context/ModalContext.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 interface ModalContextType {
     showModal: boolean;
     modalState: string;
-    newPublicId: string | null;
+    publicId: string | null;
     openModal: (state: string, id: string | null) => void;
     closeModal: () => void;
 }
@@ -24,7 +24,7 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({ children }) => {
     const router = useRouter();
     const [showModal, setShowModal] = useState<boolean>(false);
     const [modalState, setModalState] = useState<string>('');
-    const [newPublicId, setPublicId] = useState<string | null>(null);
+    const [publicId, setPublicId] = useState<string | null>(null);
 
     // Function to open a modal with specific state and public_id
     const openModal = (state: string, id: string | null) => {
@@ -56,7 +56,7 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({ children }) => {
     };
 
     return (
-        <ModalContext.Provider value={{ showModal, modalState, newPublicId, openModal, closeModal }}>
+        <ModalContext.Provider value={{ showModal, modalState, publicId, openModal, closeModal }}>
             {children}
         </ModalContext.Provider>
     );

--- a/context/ModalContext.tsx
+++ b/context/ModalContext.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 interface ModalContextType {
     showModal: boolean;
     modalState: string;
-    public_id: string | null;
+    newPublicId: string | null;
     openModal: (state: string, id: string | null) => void;
     closeModal: () => void;
 }
@@ -24,25 +24,31 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({ children }) => {
     const router = useRouter();
     const [showModal, setShowModal] = useState<boolean>(false);
     const [modalState, setModalState] = useState<string>('');
-    const [public_id, setPublicId] = useState<string | null>(null);
+    const [newPublicId, setPublicId] = useState<string | null>(null);
 
     // Function to open a modal with specific state and public_id
     const openModal = (state: string, id: string | null) => {
-        
+        document.documentElement.style.overflowY = 'hidden';
         setModalState(state);
         setPublicId(id);
         setShowModal(true);
-        
+
         // TODO: change this to push arguments to url instead of page-like stuff
         if (state === 'about') {
-            router.push("/about", undefined, { shallow: true });
+            //router.push("/about", undefined, { shallow: true });
+            router.push(`/?page=${state}`, undefined, {shallow: true});
         } else if (state === 'gallery' && id) {
-            router.push(`/gallery/${id}`, undefined, { shallow: true });
+            //router.push(`/gallery/${id}`, undefined, { shallow: true });
+            router.push(`/?gallery=${id}`, undefined, {shallow: true});
         }
+
+       
     };
 
     // Function to close the modal
     const closeModal = () => {
+        console.log("closing modal")
+        document.documentElement.style.overflowY = 'auto';
         setShowModal(false);
         setModalState('');
         setPublicId(null);
@@ -50,7 +56,7 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({ children }) => {
     };
 
     return (
-        <ModalContext.Provider value={{ showModal, modalState, public_id, openModal, closeModal }}>
+        <ModalContext.Provider value={{ showModal, modalState, newPublicId, openModal, closeModal }}>
             {children}
         </ModalContext.Provider>
     );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,13 @@
 import { AppProps } from 'next/app'
 import '../styles/globals.css';
+import { ModalProvider } from '../context/ModalContext';
 
 export default function App({ Component, pageProps }: AppProps) {
 	
 
 	return (
-		<Component {...pageProps} />
+		<ModalProvider>
+      		<Component {...pageProps} />
+    	</ModalProvider>
 	)
 }

--- a/pages/api/projectphotos.tsx
+++ b/pages/api/projectphotos.tsx
@@ -16,13 +16,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const   { folder } = req.query;
 
     if (!folder || typeof folder !== 'string') {
-      return res.status(400).json({ error: 'Invalid folder name' });
+      return res.status(400).json({ error: `Invalid folder name ${folder}` });
     }
 
     const match = folder.match(/^([^-]+)-(\d+)$/);
 
     if (!match || match.length !== 3) {
-      return res.status(400).json({ error: 'Invalid folder name format' });
+      return res.status(400).json({ error: `Invalid folder name format` });
     }
 
     const subjectName : string = match[1];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,27 +18,16 @@ interface Photo {
 
 const HeroPage: React.FC = () => {
   const router = useRouter();
-  const { showModal, modalState, newPublicId, openModal, closeModal } = useModal();
+  const { showModal, modalState, publicId, openModal, closeModal } = useModal();
 
   const [photos, setPhotos] = useState<Photo[]>([]);
   const [imageOffScreen, setImageOffScreen] = useState<boolean>(false);
   const [showGreenBar, setShowGreenBar] = useState<boolean>(false);
 
-  const [showGallery, setShowGallery] = useState<boolean>(false);
-  const [public_id, setPublicId] = useState<string | null>(null);
-  const [scrollPosition, setScrollPosition] = useState(0);
   const cld = new Cloudinary({ cloud: { cloudName: 'ddlip2prr' } });
 
- // Restore scroll position when the modal is closed
-  useEffect(() => {
-    if (!showGallery) {
-      document.documentElement.style.overflowY = 'auto'; 
-      window.scrollTo(0, scrollPosition);
-    }
-  }, [showGallery, scrollPosition]);
 
-//TODO: here we still need this logic that gets args out of url and decides what modal to open, but a lot of the "opening" and "closing" code can go in the context
-  //set showGallery and gallery publicID based on url param
+  //when router is ready, grab arguments from router to determine which modal to display. This helps us with browser navigation stuff. 
   useEffect(() => {
     //TODO: will need to scrub the url param to handle invalid args
 
@@ -46,7 +35,6 @@ const HeroPage: React.FC = () => {
 
     const gallery = router.query.gallery;
     const page = router.query.page;
-    console.log(`Why isn't refresh working? ${gallery}`)
     if (typeof gallery === 'string') {
       openModal('gallery', gallery)
 
@@ -80,30 +68,9 @@ const HeroPage: React.FC = () => {
     fetchPhotos();
   }, []);
 
-
-  //TODO: this logic can probably all be in the context, maybe not the document stuff tho, idk, and the set scroll position stuff
-
-  // open or close gallery overlay and handle disabling or enabling background scroll
-  const handleModal = (isOpening: boolean, newPublicId: string | null) => {
-    if (isOpening) {  
-      router.push(`/?gallery=${newPublicId}`, undefined, {shallow: true});
-      setShowGallery(true);
-      setScrollPosition(window.scrollY);
-      document.documentElement.style.overflowY = 'hidden';
-    } else {
-      router.push('/', undefined, { shallow: true });
-      setShowGallery(false);
-      setPublicId(null)
-      document.documentElement.style.overflowY = 'auto';
-      window.scrollTo(0, scrollPosition);
-    }
-  }
-
   const leftColumn : Photo[] = photos.filter((_, index) => index % 2 === 0);
   const rightColumn : Photo[] = photos.filter((_, index) => index % 2 !== 0);
   const columns : Photo[][] = [leftColumn, rightColumn]
-
-  //TODO: utilize new context states to control visibility of this stuff
 
   return (
     <div id="outermost_div"
@@ -120,11 +87,11 @@ const HeroPage: React.FC = () => {
         zIndex: 1, height: '600vh', justifyContent: 'center',
         overflowY : 'hidden', overflowX : 'hidden' }}>
 
-         
-          <HeroGallery columns={columns} handleModal={handleModal} /> 
+          <HeroGallery columns={columns} /> 
+
       </div>
 
-      {showModal && <Modal state={modalState} onClose={ () => closeModal()} public_id={newPublicId} /> }
+      {showModal && <Modal state={modalState} onClose={ () => closeModal()} public_id={publicId} /> }
     </div>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,11 +51,11 @@ const HeroPage: React.FC = () => {
       openModal('gallery', gallery)
 
     } else if(typeof page ==='string'){
-
+      openModal(page, null);
     } else {
       closeModal();
     }
-  }, [router.query.gallery, router.isReady]);
+  }, [router.query.gallery, router.query.page, router.isReady]);
 
   // Fetch Hero Photos
   useEffect(() => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import Modal from '../components/gallery/ModalGallery';
 import Curtain from '../components/Curtain';
 import HeroGallery from '../components/HeroGallery';
 import { HeroImageData } from '../types/types';
+import { useModal } from '../context/ModalContext';
 
 interface Photo {
   image: CloudinaryImage;
@@ -17,6 +18,7 @@ interface Photo {
 
 const HeroPage: React.FC = () => {
   const router = useRouter();
+  const { showModal, modalState, newPublicId, openModal, closeModal } = useModal();
 
   const [photos, setPhotos] = useState<Photo[]>([]);
   const [imageOffScreen, setImageOffScreen] = useState<boolean>(false);
@@ -39,15 +41,21 @@ const HeroPage: React.FC = () => {
   //set showGallery and gallery publicID based on url param
   useEffect(() => {
     //TODO: will need to scrub the url param to handle invalid args
+
+    if (!router.isReady) return; // Wait until the router is ready
+
     const gallery = router.query.gallery;
+    const page = router.query.page;
+    console.log(`Why isn't refresh working? ${gallery}`)
     if (typeof gallery === 'string') {
-      setShowGallery(true);
-      setPublicId(gallery);
+      openModal('gallery', gallery)
+
+    } else if(typeof page ==='string'){
+
     } else {
-      setShowGallery(false);
-      setPublicId(null);
+      closeModal();
     }
-  }, [router.query.gallery]);
+  }, [router.query.gallery, router.isReady]);
 
   // Fetch Hero Photos
   useEffect(() => {
@@ -116,7 +124,7 @@ const HeroPage: React.FC = () => {
           <HeroGallery columns={columns} handleModal={handleModal} /> 
       </div>
 
-      {showGallery && <Modal state='gallery' onClose={ () => handleModal(false, null)} public_id={public_id} /> }
+      {showModal && <Modal state={modalState} onClose={ () => closeModal()} public_id={newPublicId} /> }
     </div>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -35,7 +35,7 @@ const HeroPage: React.FC = () => {
     }
   }, [showGallery, scrollPosition]);
 
-
+//TODO: here we still need this logic that gets args out of url and decides what modal to open, but a lot of the "opening" and "closing" code can go in the context
   //set showGallery and gallery publicID based on url param
   useEffect(() => {
     //TODO: will need to scrub the url param to handle invalid args
@@ -72,6 +72,9 @@ const HeroPage: React.FC = () => {
     fetchPhotos();
   }, []);
 
+
+  //TODO: this logic can probably all be in the context, maybe not the document stuff tho, idk, and the set scroll position stuff
+
   // open or close gallery overlay and handle disabling or enabling background scroll
   const handleModal = (isOpening: boolean, newPublicId: string | null) => {
     if (isOpening) {  
@@ -92,6 +95,8 @@ const HeroPage: React.FC = () => {
   const rightColumn : Photo[] = photos.filter((_, index) => index % 2 !== 0);
   const columns : Photo[][] = [leftColumn, rightColumn]
 
+  //TODO: utilize new context states to control visibility of this stuff
+
   return (
     <div id="outermost_div"
       style={{ display: 'flex', justifyContent: 'center',
@@ -107,11 +112,11 @@ const HeroPage: React.FC = () => {
         zIndex: 1, height: '600vh', justifyContent: 'center',
         overflowY : 'hidden', overflowX : 'hidden' }}>
 
-        {!showGallery && 
-          <HeroGallery columns={columns} handleModal={handleModal} /> }
-        </div>
+         
+          <HeroGallery columns={columns} handleModal={handleModal} /> 
+      </div>
 
-      {showGallery && <Modal onClose={ () => handleModal(false, null)} public_id={public_id} /> }
+      {showGallery && <Modal state='gallery' onClose={ () => handleModal(false, null)} public_id={public_id} /> }
     </div>
   );
 };

--- a/styles/Footer.module.css
+++ b/styles/Footer.module.css
@@ -1,0 +1,21 @@
+.footer {
+    position: fixed;
+    bottom: 0px;
+    right: 35px;
+    z-index: 10;
+    color: black;
+    height: 30px;
+    font-family: "KAMAR", sans-serif;
+  }
+ß
+
+  .menuitem {
+    display: flex;
+    cursor: default;
+    scroll-margin: 0.5rem;
+    align-items: center;
+    gap: 2rem;
+    border-radius: 0.25rem;
+    padding: 0.5rem;
+    outline: none !important;
+  }

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -55,22 +55,15 @@
   }
 }
 
-.footer {
-  position: fixed;
-  bottom: 0px;
-  right: 35px;
-  z-index: 10;
-  color: black;
-  height: 30px;
-}
+
 
 .menu {
   align-items: flex-end;
   position: relative;
   z-index: 50;
   display: flex;
-  min-width: 200px;
-  min-height: 180px;
+  min-width: 150px;
+  height: 100px;
   flex-direction: column;
   overscroll-behavior: contain;
   background-color: clear;
@@ -80,15 +73,6 @@
   max-height: max-content;
   overflow: visible;
   font-weight: bold;
+  cursor: pointer;
 }
 
-.menuitem {
-  display: flex;
-  cursor: default;
-  scroll-margin: 0.5rem;
-  align-items: center;
-  gap: 0.5rem;
-  border-radius: 0.25rem;
-  padding: 0.5rem;
-  outline: none !important;
-}

--- a/styles/Modal.module.css
+++ b/styles/Modal.module.css
@@ -1,0 +1,38 @@
+.modalWrapper {
+  width: 100dvw;
+  height: 100dvh;
+}
+
+.modal {
+  display: flex;
+  align-items: center;
+  background: white;
+  height: 100%;
+  width: 100%;
+}
+
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 42;
+}
+
+.modalBody {
+  height: auto;
+  /* Allows child to scroll */
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.modalHeader {
+  display: flex;
+  justify-content: flex-end;
+  font-size: 25px;
+}

--- a/styles/ScrollIndicator.module.css
+++ b/styles/ScrollIndicator.module.css
@@ -100,3 +100,33 @@
 .bottomRightBase {
   right: 0;
 }
+
+.invisibleButton {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100px;  /* Adjust width to cover "INDEX" */
+  height: 30px;  /* Adjust height to cover text area */
+  background: none;
+  border: none;
+  cursor: pointer;
+  z-index: 15;  /* Ensure it sits above other elements */
+  opacity: 0;   /* Make the button invisible */
+}
+
+.invisibleMenuButton{
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 100px;
+  height: 30px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  z-index: 15;
+  opacity: 0;
+}
+
+.invisibleButton:focus {
+  outline: none;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,6 +5,13 @@ body {
   overflow: hidden;
 }
 
+@font-face {
+  font-family: "KAMAR";
+  src: url("/fonts/KAMAR.ttf") format("truetype");
+  font-weight: bold;
+  font-style: normal;
+}
+
 .modal-wrapper {
   width: 100dvw;
   height: 100dvh;


### PR DESCRIPTION
Set up a way for us to easily open and close a modal window using new ModalContext.tsx.  Wrapped the whole app in a context provider in _app.tsx, then from anywhere you can simply use the useModal hook to access 
- showModal boolean : whether or not modal is showing
- modalState string : options right now are 'gallery', 'about' and 'coffee'
- publicId string : if gallery is open it's used to retrieve gallery photos
- openModal(string state, publicId string | null) : opensModal to any page we want or to the gallery
- closeModal() : simply closes modal and resets public id

To add a new page, just need to add a piece of conditionally rendered code to ModalGallery.tsx, then use the new context functions to open the modal.

I also added some small style changes. 