### PR TITLE
John/gallery hover

### DIFF
--- a/components/HeroGallery/HeroGalleryGroup.tsx
+++ b/components/HeroGallery/HeroGalleryGroup.tsx
@@ -33,20 +33,20 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
   const handleImageLoad = (imageId: string, event: React.SyntheticEvent<HTMLImageElement>) => {
     const img = event.currentTarget;
     const rect = img.getBoundingClientRect();
-    
+
     // For left column images, calculate the actual image display area
     if (imageId.includes('leftColumnImage')) {
       const naturalWidth = img.naturalWidth;
       const naturalHeight = img.naturalHeight;
       const containerWidth = rect.width;
       const containerHeight = rect.height;
-      
+
       // Calculate the actual display dimensions for object-fit: fill with object-position: right
       const imageAspectRatio = naturalWidth / naturalHeight;
       const containerAspectRatio = containerWidth / containerHeight;
-      
+
       let displayWidth, displayHeight;
-      
+
       if (imageAspectRatio > containerAspectRatio) {
         // Image is wider than container - height fills container, width is calculated
         displayHeight = containerHeight;
@@ -56,7 +56,7 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
         displayWidth = containerWidth;
         displayHeight = containerWidth / imageAspectRatio;
       }
-      
+
       setOverlayDimensions(prev => ({
         ...prev,
         [imageId]: {
@@ -88,7 +88,7 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
           right: '0'
         };
       }
-      
+
       return {
         width: `${dimensions.width}px`,
         height: `${dimensions.height}px`
@@ -181,12 +181,13 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
     const description = descriptions[folderName];
     const title1 = getGalleryTitle1(folderName);
     const title2 = getGalleryTitle2(folderName);
-   
+
+
     return (
-      <div style={{ 
-        display: 'flex', 
-        flexDirection: 'column', 
-        justifyContent: 'center', 
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
         alignItems: 'center',
         width: '100%',
         height: '100%',
@@ -194,21 +195,30 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
         boxSizing: 'border-box',
         overflow: 'hidden'
       }}>
-        <AutoScaleText 
-          parentId={parentId} 
-          text={title1} 
-          widthPercentage={90} 
-          maxFontSize={24}
-          minFontSize={6}
-        />
-        <AutoScaleText 
-          parentId={parentId} 
-          text={title2} 
-          widthPercentage={90} 
-          maxFontSize={18}
-          minFontSize={4}
-        />
+        <div
+          style={{
+            fontSize: `clamp(12px, 2vw, 50px)`,
+            whiteSpace: "normal", // keep one line
+            width: "100%",
+            textAlign: "center",
+            marginBottom: "8px"
+          }}
+        >
+          {title1}
+        </div>
+        <div
+          style={{
+            fontSize: `clamp(12px, 3vw, 50px)`,
+            whiteSpace: "normal", // keep one line
+            width: "100%",
+            textAlign: "center",
+            marginBottom: "8px"
+          }}
+        >
+          {title2}
+        </div>
       </div>
+
     );
   };
 
@@ -281,10 +291,10 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
                 >
                   <AdvancedImage
                     id={`leftColumnImage-${groupIndex}-${index}-${photo.publicId}`}
-                    className={styles.clickablePhoto} 
-                    onClick={() => openModal('gallery', photo.folderName)} 
+                    className={styles.clickablePhoto}
+                    onClick={() => openModal('gallery', photo.folderName)}
                     onContextMenu={preventRightClick}
-                    cldImg={generateUrl(photo.publicId)} 
+                    cldImg={generateUrl(photo.publicId)}
                     style={{ objectFit: 'fill', objectPosition: 'right', height: '100%' }}
                     onLoad={(e: React.SyntheticEvent<HTMLImageElement>) => handleImageLoad(`leftColumnImage-${groupIndex}-${index}-${photo.publicId}`, e)}
                   />
@@ -298,7 +308,7 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
                     onMouseLeave={() => handleOverlayMouseLeave(`leftColumnImage-${groupIndex}-${index}-${photo.publicId}`)}
                     onClick={() => handleOverlayClick(`leftColumnImage-${groupIndex}-${index}-${photo.publicId}`, photo.folderName)}
                   >
-                    {newGetGalleryTitles(photo.folderName, `leftColumnImage-${groupIndex}-${index}-${photo.publicId}`)}
+                    {newGetGalleryTitles(photo.folderName, `leftColumnImage-${groupIndex}-${index}-${photo.publicId}-overlay`)}
                   </div>
                 </div>
               ))}
@@ -319,7 +329,7 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
                     style={{ display: 'block', height: '100%', objectFit: 'contain', objectPosition: 'left' }}
                     onLoad={(e: React.SyntheticEvent<HTMLImageElement>) => handleImageLoad(`rightColumnImage-${groupIndex}-${index}-${photo.publicId}`, e)}
                   />
-                  <div 
+                  <div
                     className={overlayStyles.overlay}
                     style={{
                       ...getOverlayStyle(`rightColumnImage-${groupIndex}-${index}-${photo.publicId}`),

--- a/components/HeroGallery/HeroGalleryGroup.tsx
+++ b/components/HeroGallery/HeroGalleryGroup.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { AdvancedImage, lazyload } from '@cloudinary/react';
 import { Cloudinary } from '@cloudinary/url-gen';
-import { GalleryGroup } from '../../types/types';
+import { GalleryGroup, GalleryDescription } from '../../types/types';
 
 import styles from '../../styles/HeroGallery.module.css'
+import overlayStyles from '../../styles/HeroGalleryOverlay.module.css';
 import { useAppContext } from '../../context/AppContext';
 import { auto } from '@cloudinary/url-gen/actions/resize';
+import AutoScaleText from '../common/AutoScaleText';
+
 
 interface HeroGalleryProps {
   group: GalleryGroup;
@@ -22,8 +25,130 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
 
   const { openModal } = useAppContext();
   const [windowWidth, setWindowWidth] = useState<number | null>(null);
+  const [descriptions, setDescriptions] = useState<{ [key: string]: GalleryDescription }>({});
+  const [overlayDimensions, setOverlayDimensions] = useState<{ [key: string]: { width: number; height: number } }>({});
+  const [overlayHoverStates, setOverlayHoverStates] = useState<{ [key: string]: boolean }>({});
+
+  // Function to calculate image dimensions and set overlay size
+  const handleImageLoad = (imageId: string, event: React.SyntheticEvent<HTMLImageElement>) => {
+    const img = event.currentTarget;
+    const rect = img.getBoundingClientRect();
+    
+    // For left column images, calculate the actual image display area
+    if (imageId.includes('leftColumnImage')) {
+      const naturalWidth = img.naturalWidth;
+      const naturalHeight = img.naturalHeight;
+      const containerWidth = rect.width;
+      const containerHeight = rect.height;
+      
+      // Calculate the actual display dimensions for object-fit: fill with object-position: right
+      const imageAspectRatio = naturalWidth / naturalHeight;
+      const containerAspectRatio = containerWidth / containerHeight;
+      
+      let displayWidth, displayHeight;
+      
+      if (imageAspectRatio > containerAspectRatio) {
+        // Image is wider than container - height fills container, width is calculated
+        displayHeight = containerHeight;
+        displayWidth = containerHeight * imageAspectRatio;
+      } else {
+        // Image is taller than container - width fills container, height is calculated
+        displayWidth = containerWidth;
+        displayHeight = containerWidth / imageAspectRatio;
+      }
+      
+      setOverlayDimensions(prev => ({
+        ...prev,
+        [imageId]: {
+          width: displayWidth,
+          height: displayHeight
+        }
+      }));
+    } else {
+      setOverlayDimensions(prev => ({
+        ...prev,
+        [imageId]: {
+          width: rect.width,
+          height: rect.height
+        }
+      }));
+    }
+  };
+
+  // Function to get overlay dimensions for a specific image
+  const getOverlayStyle = (imageId: string) => {
+    const dimensions = overlayDimensions[imageId];
+    if (dimensions) {
+      // For left column images, use the calculated display dimensions
+      if (imageId.includes('leftColumnImage')) {
+        return {
+          width: `${dimensions.width}px`,
+          height: `${dimensions.height}px`,
+          left: 'auto',
+          right: '0'
+        };
+      }
+      
+      return {
+        width: `${dimensions.width}px`,
+        height: `${dimensions.height}px`
+      };
+    }
+    return {};
+  };
+
+  // Function to handle overlay hover events
+  const handleOverlayMouseEnter = (imageId: string) => {
+    setOverlayHoverStates(prev => ({
+      ...prev,
+      [imageId]: true
+    }));
+  };
+
+  const handleOverlayMouseLeave = (imageId: string) => {
+    setOverlayHoverStates(prev => ({
+      ...prev,
+      [imageId]: false
+    }));
+  };
+
+  // Function to get overlay visibility
+  const getOverlayVisibility = (imageId: string) => {
+    return overlayHoverStates[imageId] ? 1 : 0;
+  };
+
+  // Function to handle overlay click - pass through to image
+  const handleOverlayClick = (imageId: string, folderName: string) => {
+    // Trigger the modal open
+    openModal('gallery', folderName);
+  };
 
   useEffect(() => {
+    const fetchDescriptions = async () => {
+      const newDescriptions: { [key: string]: GalleryDescription } = {};
+      for (const photo of group.leftColumn) {
+        if (!descriptions[photo.folderName]) {
+          const res = await fetch(`/api/projectAssets?folder=${photo.folderName}`);
+          const data = await res.json();
+          newDescriptions[photo.folderName] = data.description;
+        }
+      }
+      for (const photo of group.rightColumn) {
+        if (!descriptions[photo.folderName]) {
+          const res = await fetch(`/api/projectAssets?folder=${photo.folderName}`);
+          const data = await res.json();
+          newDescriptions[photo.folderName] = data.description;
+        }
+      }
+      if (group.widePhoto && !descriptions[group.widePhoto.folderName]) {
+        const res = await fetch(`/api/projectAssets?folder=${group.widePhoto.folderName}`);
+        const data = await res.json();
+        newDescriptions[group.widePhoto.folderName] = data.description;
+      }
+      setDescriptions(prev => ({ ...prev, ...newDescriptions }));
+    }
+    fetchDescriptions();
+
     // Set window width only on the client
     setWindowWidth(window.innerWidth);
 
@@ -31,7 +156,61 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
     window.addEventListener('resize', handleResize);
 
     return () => window.removeEventListener('resize', handleResize);
-  }, []);
+  }, [group]);
+
+  const getGalleryTitle1 = (folderName: string) => {
+    const description = descriptions[folderName];
+
+    //TESTING: defaulting to subject since we have all of those
+    return description?.subject; //DEFAULT TO CLOVER MODE IF TITLE NOT CONFIGURED
+
+
+    return description?.mainGalleryTitle1 == null || description?.mainGalleryTitle1 == '' ? "ClOVER MODE CLOVER MODE" : description?.mainGalleryTitle1; //DEFAULT TO CLOVER MODE IF TITLE NOT CONFIGURED
+  };
+
+  const getGalleryTitle2 = (folderName: string) => {
+    const description = descriptions[folderName];
+    //TESTING: defaulting to regular title since we have those for now
+    return description?.title; //DEFAULT TO CLOVER MODE IF TITLE NOT CONFIGURED
+
+    return description?.mainGalleryTitle2 == null || description?.mainGalleryTitle2 == '' ? "CLOVER MODE" : description?.mainGalleryTitle2; //DEFAULT TO CLOVER MODE IF TITLE NOT CONFIGURED
+
+  };
+
+  const newGetGalleryTitles = (folderName: string, parentId: string) => {
+    const description = descriptions[folderName];
+    const title1 = getGalleryTitle1(folderName);
+    const title2 = getGalleryTitle2(folderName);
+   
+    return (
+      <div style={{ 
+        display: 'flex', 
+        flexDirection: 'column', 
+        justifyContent: 'center', 
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        padding: '8px',
+        boxSizing: 'border-box',
+        overflow: 'hidden'
+      }}>
+        <AutoScaleText 
+          parentId={parentId} 
+          text={title1} 
+          widthPercentage={90} 
+          maxFontSize={24}
+          minFontSize={6}
+        />
+        <AutoScaleText 
+          parentId={parentId} 
+          text={title2} 
+          widthPercentage={90} 
+          maxFontSize={18}
+          minFontSize={4}
+        />
+      </div>
+    );
+  };
 
   const calculateHeight = (columnLength: number, groupIndex: number) => { // For hero groups
     const isMobile = (windowWidth ?? 1024) <= 768; // Fallback to 1024 for SSR
@@ -53,12 +232,12 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
       VIDEO: { mobile: ['70vw', '65vw', '60vw', '70vw', '60vw'], desktop: ['50dvw', '50dvw', '48dvw', '40dvw', '40vw'] },
       CLOVERPRODUCTION: { mobile: ['65vw', '70vw', '80vw', '75vw'], desktop: ['45dvw', '50dvw', '70dvw', '60dvw'] },
     };
-  
+
     const fallbackWidth = windowWidth ?? 1024; // Default to 1024 if null
     return widths[filterState as keyof typeof widths]?.[isMobile ? 'mobile' : 'desktop'][groupIndex] ??
       `${fallbackWidth <= 768 ? 70 : 50}vw`;
   };
-  
+
 
 
 
@@ -76,13 +255,15 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
         {/* Wide photo spanning both columns */}
         {group.widePhoto && (
           <div className={styles.widePhotoContainer} style={{ width: calculateWidth(groupIndex) }}>
-            <div style={{ width: '100%', paddingTop: '4px' }}>
-              <AdvancedImage
+            <div className={`${styles.widePhotoFlex} ${overlayStyles.itemContainer}`}>
+              <AdvancedImage id={`widePhotoImage-${groupIndex}-${group.widePhoto.publicId}`}
                 onClick={() => openModal('gallery', group.widePhoto.folderName)}
                 onContextMenu={preventRightClick} cldImg={generateUrl(group.widePhoto.publicId)}
                 className={styles.widePhoto}
-                // plugins={[lazyload({ rootMargin: '10px 20px 10px 30px', threshold: 0.25 })]}
               />
+              <div className={overlayStyles.overlay}>
+                {newGetGalleryTitles(group.widePhoto.folderName, `widePhotoImage-${groupIndex}-${group.widePhoto.publicId}`)}
+              </div>
             </div>
           </div>
         )}
@@ -90,40 +271,72 @@ const HeroGallery: React.FC<HeroGalleryProps> = ({ group, filterState, groupInde
         {/* VARYING HEIGHT OF COLUMNS BASED ON NUMBER OF PHOTOS IN THE COLUMN
         if there are 5 photos, height stays the same, */}
         {group.leftColumn.length > 0 && group.rightColumn.length > 0 &&
-         <div style={{ display: 'flex', gap: '8px', height: calculateHeight(group.leftColumn.length, groupIndex), }}>
+          <div style={{ display: 'flex', gap: '8px', height: calculateHeight(group.leftColumn.length, groupIndex), }}>
 
-         {/* Left Column */}
-         <div className={styles.leftColumnContainer}>
-           {group.leftColumn.map((photo, index) => (
-             <div className={styles.leftColumnFlex}
-               style={{ height: `${group.leftColumnHeights[index]}%` }}
-             >
-               <AdvancedImage
-                 className={styles.clickablePhoto} onClick={() => openModal('gallery', photo.folderName)} onContextMenu={preventRightClick}
-                 cldImg={generateUrl(photo.publicId)} style={{ objectFit: 'fill', objectPosition: 'right',  height: '100%' }}
-                  // plugins={[lazyload({ rootMargin: '10px 20px 10px 30px', threshold: 0.25 })]}
-               />
-             </div>
-           ))}
-         </div>
+            {/* Left Column */}
+            <div className={styles.leftColumnContainer}>
+              {group.leftColumn.map((photo, index) => (
+                <div className={`${styles.leftColumnFlex} ${overlayStyles.itemContainer}`}
+                  style={{ height: `${group.leftColumnHeights[index]}%` }}
+                >
+                  <AdvancedImage
+                    id={`leftColumnImage-${groupIndex}-${index}-${photo.publicId}`}
+                    className={styles.clickablePhoto} 
+                    onClick={() => openModal('gallery', photo.folderName)} 
+                    onContextMenu={preventRightClick}
+                    cldImg={generateUrl(photo.publicId)} 
+                    style={{ objectFit: 'fill', objectPosition: 'right', height: '100%' }}
+                    onLoad={(e: React.SyntheticEvent<HTMLImageElement>) => handleImageLoad(`leftColumnImage-${groupIndex}-${index}-${photo.publicId}`, e)}
+                  />
+                  <div 
+                    className={overlayStyles.overlay}
+                    style={{
+                      ...getOverlayStyle(`leftColumnImage-${groupIndex}-${index}-${photo.publicId}`),
+                      opacity: getOverlayVisibility(`leftColumnImage-${groupIndex}-${index}-${photo.publicId}`)
+                    }}
+                    onMouseEnter={() => handleOverlayMouseEnter(`leftColumnImage-${groupIndex}-${index}-${photo.publicId}`)}
+                    onMouseLeave={() => handleOverlayMouseLeave(`leftColumnImage-${groupIndex}-${index}-${photo.publicId}`)}
+                    onClick={() => handleOverlayClick(`leftColumnImage-${groupIndex}-${index}-${photo.publicId}`, photo.folderName)}
+                  >
+                    {newGetGalleryTitles(photo.folderName, `leftColumnImage-${groupIndex}-${index}-${photo.publicId}`)}
+                  </div>
+                </div>
+              ))}
+            </div>
 
-         {/* Right Column */}
-         <div className={styles.rightColumnContainer}>
-           {group.rightColumn.map((photo, index) => (
-             <div className={styles.rightColumnFlex}
-               style={{ height: `${group.rightColumnHeights[index]}%` }}
-             >
-               <AdvancedImage
-                 className={styles.clickablePhoto} onClick={() => openModal('gallery', photo.folderName)} onContextMenu={preventRightClick}
-                 cldImg={generateUrl(photo.publicId)} style={{ objectFit: 'fill', objectPosition: 'left', height: '100%' }}
-                  // plugins={[lazyload({ rootMargin: '10px 20px 10px 30px', threshold: 0.25 })]}
-               />
-             </div>
-           ))}
-         </div>
-       </div>
+            {/* Right Column */}
+            <div className={styles.rightColumnContainer}>
+              {group.rightColumn.map((photo, index) => (
+                <div className={`${styles.rightColumnFlex} ${overlayStyles.itemContainer}`}
+                  style={{ height: `${group.rightColumnHeights[index]}%` }}
+                >
+                  <AdvancedImage
+                    id={`rightColumnImage-${groupIndex}-${index}-${photo.publicId}`}
+                    className={styles.clickablePhoto}
+                    onClick={() => openModal('gallery', photo.folderName)}
+                    onContextMenu={preventRightClick}
+                    cldImg={generateUrl(photo.publicId)}
+                    style={{ display: 'block', height: '100%', objectFit: 'contain', objectPosition: 'left' }}
+                    onLoad={(e: React.SyntheticEvent<HTMLImageElement>) => handleImageLoad(`rightColumnImage-${groupIndex}-${index}-${photo.publicId}`, e)}
+                  />
+                  <div 
+                    className={overlayStyles.overlay}
+                    style={{
+                      ...getOverlayStyle(`rightColumnImage-${groupIndex}-${index}-${photo.publicId}`),
+                      opacity: getOverlayVisibility(`rightColumnImage-${groupIndex}-${index}-${photo.publicId}`)
+                    }}
+                    onMouseEnter={() => handleOverlayMouseEnter(`rightColumnImage-${groupIndex}-${index}-${photo.publicId}`)}
+                    onMouseLeave={() => handleOverlayMouseLeave(`rightColumnImage-${groupIndex}-${index}-${photo.publicId}`)}
+                    onClick={() => handleOverlayClick(`rightColumnImage-${groupIndex}-${index}-${photo.publicId}`, photo.folderName)}
+                  >
+                    {newGetGalleryTitles(photo.folderName, `rightColumnImage-${groupIndex}-${index}-${photo.publicId}`)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
         }
-       
+
       </React.Fragment>
     </div>
   );

--- a/components/HeroGallery/HeroGalleryImage.tsx
+++ b/components/HeroGallery/HeroGalleryImage.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { AdvancedImage } from '@cloudinary/react';
+import { CloudinaryImage } from '@cloudinary/url-gen';
+
+interface HeroGalleryImageProps {
+  photo: any; // Replace 'any' with actual type if available
+  generateUrl: (publicId: string) => CloudinaryImage;
+  openModal: (type: string, folderName: string) => void;
+  preventRightClick: (e: React.MouseEvent) => void;
+  getGalleryTitles: (folderName: string) => JSX.Element;
+  styles: any; // Replace 'any' with actual type if available
+  overlayStyles: any; // Replace 'any' with actual type if available
+  imageWrapperStyle?: React.CSSProperties;
+  imageStyle?: React.CSSProperties;
+}
+
+const HeroGalleryImage: React.FC<HeroGalleryImageProps> = ({
+  photo,
+  generateUrl,
+  openModal,
+  preventRightClick,
+  getGalleryTitles,
+  styles,
+  overlayStyles,
+  imageWrapperStyle,
+  imageStyle,
+}) => {
+  const [overlayWidth, setOverlayWidth] = useState<number | null>(null);
+  const [showOverlay, setShowOverlay] = useState<boolean>(false);
+
+  return (
+    <div className={overlayStyles.imageWrapper} style={imageWrapperStyle}>
+      <AdvancedImage
+        onClick={() => openModal('gallery', photo.folderName)}
+        onContextMenu={preventRightClick}
+        cldImg={generateUrl(photo.publicId)}
+        className={styles.clickablePhoto}
+        style={imageStyle}
+        onMouseOver={(e) => {
+          setOverlayWidth(e.currentTarget.offsetWidth);
+          setShowOverlay(true);
+        }}
+        onMouseOut={() => {
+          setShowOverlay(false);
+          setOverlayWidth(null);
+        }}
+      />
+      <div className={overlayStyles.overlay} style={{ width: overlayWidth ? `${overlayWidth}px` : '100%', opacity: showOverlay ? 1 : 0 }}>
+        {getGalleryTitles(photo.folderName)}
+      </div>
+    </div>
+  );
+};
+
+export default HeroGalleryImage;

--- a/components/HeroGallery/ImageWithOverlayProps.tsx
+++ b/components/HeroGallery/ImageWithOverlayProps.tsx
@@ -1,0 +1,57 @@
+import React, { useRef, useState, useEffect } from "react";
+import { AdvancedImage } from "@cloudinary/react";
+
+interface ImageWithOverlayProps {
+  photo: any;
+  height?: string;
+  cldImg: any;
+  getGalleryTitles: (folderName: string) => React.ReactNode;
+  openModal: (type: string, folderName: string) => void;
+  preventRightClick: (e: React.MouseEvent) => void;
+  className?: string;
+  overlayClass?: string;
+  style?: React.CSSProperties;
+}
+
+const ImageWithOverlay: React.FC<ImageWithOverlayProps> = ({
+  photo,
+  height,
+  cldImg,
+  getGalleryTitles,
+  openModal,
+  preventRightClick,
+  className,
+  overlayClass,
+  style
+}) => {
+  const imgRef = useRef<HTMLImageElement | null>(null);
+  const [imgWidth, setImgWidth] = useState<number>(0);
+
+  useEffect(() => {
+    const updateWidth = () => {
+      if (imgRef.current) {
+        setImgWidth(imgRef.current.offsetWidth);
+      }
+    };
+    updateWidth();
+    window.addEventListener("resize", updateWidth);
+    return () => window.removeEventListener("resize", updateWidth);
+  }, []);
+
+  return (
+    <div style={{ height }} className={className}>
+      <AdvancedImage
+        ref={imgRef}
+        onClick={() => openModal("gallery", photo.folderName)}
+        onContextMenu={preventRightClick}
+        cldImg={cldImg}
+        style={{ height: "100%", ...style }}
+      />
+      <div className={overlayClass} style={{ width: imgWidth }}>
+        {getGalleryTitles(photo.folderName)}
+      </div>
+    </div>
+  );
+};
+
+export default ImageWithOverlay;

--- a/components/common/AutoScaleText.tsx
+++ b/components/common/AutoScaleText.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useRef, useState } from "react";
+
+interface AutoScaleTextProps {
+  text: string;
+  maxFontSize?: number; // optional, so it doesn't blow up too big
+  minFontSize?: number; // optional, so it doesn't shrink too tiny
+  widthPercentage?: number;
+  className?: string;
+  parentId?: string;
+  onMouseEnter?: () => void;
+}
+
+const AutoScaleText: React.FC<AutoScaleTextProps> = ({
+  text,
+  maxFontSize = 100,
+  minFontSize = 12,
+  widthPercentage = 100,
+  className,
+  parentId,
+  onMouseEnter
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [fontSize, setFontSize] = useState(maxFontSize);
+  const [isCalculated, setIsCalculated] = useState(false);
+
+  const calculateFontSize = () => {
+    const el = ref.current;
+    if (!el) return;
+
+    // Use parentId if given, otherwise fallback to natural parent
+    let parent = parentId
+      ? document.getElementById(parentId)
+      : el.parentElement;
+    if (!parent) return;
+    
+    // Get the overlay container (the actual visible area)
+    const overlay = parent.querySelector('.overlay') as HTMLElement;
+    if (!overlay) return;
+    
+    let overlayWidth = overlay.offsetWidth;
+    let overlayHeight = overlay.offsetHeight;
+    
+    if (overlayWidth === 0 || overlayHeight === 0) return;
+
+    // Set initial font size to max to measure natural size
+    el.style.fontSize = `${maxFontSize}px`;
+    
+    // Get the text container that holds both text elements
+    const textContainer = el.parentElement;
+    if (!textContainer) return;
+    
+    // Calculate available space with generous padding
+    const availableWidth = overlayWidth * 0.9; // 90% of overlay width
+    const availableHeight = overlayHeight * 0.7; // 70% of overlay height (more conservative)
+    
+    // Measure the text container with both text elements
+    const textContainerHeight = textContainer.scrollHeight;
+    const textContainerWidth = textContainer.scrollWidth;
+    
+    // Calculate scale factors for both width and height
+    const widthScale = availableWidth / textContainerWidth;
+    const heightScale = availableHeight / textContainerHeight;
+    
+    // Use the smaller scale factor to ensure both dimensions fit
+    const scaleFactor = Math.min(widthScale, heightScale, 1);
+    
+    let newSize = maxFontSize * scaleFactor;
+    
+    // Apply constraints - but prioritize fitting over max size
+    if (newSize > maxFontSize) {
+      newSize = maxFontSize;
+    }
+    if (newSize < minFontSize) {
+      newSize = minFontSize;
+    }
+    
+    // Set the calculated size and mark as calculated
+    setFontSize(newSize);
+    setIsCalculated(true);
+  };
+
+  const handleMouseEnter = () => {
+    // Only calculate once when first hovered
+    if (!isCalculated) {
+      // Wait for the overlay transition to complete before calculating
+      setTimeout(() => {
+        calculateFontSize();
+      }, 350); // Wait for the 0.3s transition + buffer
+    }
+    
+    if (onMouseEnter) {
+      onMouseEnter();
+    }
+  };
+
+  useEffect(() => {
+    // Reset calculation state when text or parentId changes
+    setIsCalculated(false);
+  }, [text, parentId]);
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      onMouseEnter={handleMouseEnter}
+      style={{
+        fontSize: `${fontSize}px`,
+        whiteSpace: "normal", // allow wrapping for very long text
+        wordWrap: "break-word",
+        overflowWrap: "break-word",
+        width: "100%",
+        textAlign: "center",
+        lineHeight: "1.1",
+        maxHeight: "50%", // Ensure it doesn't take more than half the container
+        overflow: "hidden"
+      }}
+    >
+      {text}
+    </div>
+  );
+};
+
+export default AutoScaleText;

--- a/pages/api/data/HeroGalleryGroups.json
+++ b/pages/api/data/HeroGalleryGroups.json
@@ -542,7 +542,7 @@
     {
       "widePhoto": {
         "publicId": "RADCLIFFE_GQ__1",
-        "folderName": "GQDanielRadCliff-1"
+        "folderName": "GQDanielRadCliff-7"
       },
       "leftColumn": [
         {
@@ -551,7 +551,7 @@
         },
         {
           "publicId": "FortnitexMetallica_-0",
-          "folderName": "FortnitexMetallica_-9"
+          "folderName": "FortniteXMetallica_-9"
         },
         {
           "publicId": "MARC_JACOBS_KIDS_11",

--- a/pages/api/data/galleryDescriptions.json
+++ b/pages/api/data/galleryDescriptions.json
@@ -4,504 +4,755 @@
     "title": "Go Beyond",
     "subject": "Nike Air Max",
     "functions": "Creative Development, Photodesign",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "Eminem-4",
     "title": "The Death of Slim Shady",
     "subject": "Eminem",
     "functions": "Creative, Photography, Post Production",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "JordanFrance-8",
     "title": "Home Never Leaves You",
     "subject": "Jordan FFBB",
     "functions": "Creative Pre-Production, Photodesign",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "RasingCanes_-6",
     "title": "#1 Box Combo, No Coleslaw, Extra Toast",
     "subject": "Raising Canes x ASSC",
     "functions": "Creative Development, Photodesign, Post Production",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "LYFESTYLE-6",
     "title": "Lyfestyle",
     "subject": "Yeat",
     "functions": "Creative Development, Photodesign, Post Production",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "AIRMAX_SS22",
     "title": "Go Beyond",
     "subject": "Nike Air Max",
     "functions": "Creative Development, Photodesign",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "EMINEM",
     "title": "Just The Two Of Us",
     "subject": "Eminem as Marshall Mathers and Slim Shady for Complex Magazine",
     "functions": "Creative Development, Photodesign, Post Production",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "COMPLEX_EMBELLISHMENT",
     "title": "Embelishment",
     "subject": "Complex Magazine",
     "functions": "Production, Creative Development, Photodesign",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "GiggsBBC",
     "title": "Giggs for BBC Classics",
     "subject": "Billionaire Boys Club ",
     "functions": "Production, Creative Development, Photodesign",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "JAYSON_TATUM",
     "title": "Jayson Tatum 1",
     "subject": "Jayson Tatum for Jordan",
     "functions": "Creative Development, Photodesign",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "CosMcs", 
     "title": "Galaxy",
     "subject": "CosMc's",
     "functions": "Production, Creative Development, Photodesign",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "EHNikeAirMax-1",
     "title": "Errling Haaland",
     "subject": "Nike Air Max",
     "functions": "Creative Development, Photodesign",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "Clipse-40",
     "title": "Let God Sort Em Out",
     "subject": "Clipse",
     "functions": "Creative, Photography, Post Production",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "AngusCloudR.I.P-10",
     "title": "Head In The Clouds",
     "subject": "Angus Cloud for SNS",
     "functions": "Creative Development, Photodesign, Post Production",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "EBAY",
     "title": "Authenticity Guaranteed",
     "subject": "eBay",
     "functions": "Creative Development, Photodesign",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "PNY",
     "title": "Punkandyo",
     "subject": "Punkandyo x Vans for Sneeze Magazine",
     "functions": "Production, Creative Development, Photodesign, Post Production",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "NO_CAPS",
     "title": "No Caps",
     "subject": "Eric Emanuel for MLB",
     "functions": "Creative Development, Director",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "GAB3",
     "title": "Gab3",
     "subject": "Gab3",
     "functions": "Creative, Photodesign, Post Production",
-    "year": "2021"
+    "year": "2021",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "YSLSlimeLang-8",
     "title": "Slime Language 2",
     "subject": "YSL (Young Stoner Life)",
     "functions": "Creative Development, Photography, Post Production",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "GQDanielRadCliff-7",
     "title": "Daniel Radcliffe",
     "subject": "Daniel Radcliffe for GQ",
     "functions": "Creative Development, Photodesign, Post Production",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "SheckWesBeast_-8",
     "title": "Beast",
     "subject": "Sheck Wes",
     "functions": "Production, Creative Development, Director, Photography",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "EBAYNewauthen-20",
     "title": "Authenticity Guaranteed",
     "subject": "eBay",
     "functions": "Creative Development, Photodesign",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "DIEUSON_OCTAVE",
     "title": "Dieuson Octave",
     "subject": "Kodak Black",
     "functions": "Production, Creative Development, Photography, Post Production",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "CLOVER_MODE",
     "title": "Day In The Life of Clovermode",
     "subject": "Hypebeast Magazine",
     "functions": "Production, Creative Development, Photodesign, Post Production",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "HAGD_CLOVER",
     "title": "Have a Clover Day",
     "subject": "Have a Great Day Magazine",
     "functions": "Production, Creative Development, Photodesign, Post Production",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "JordanAir_-5",
     "title": "Behind the Design", 
     "subject": "Jordan",
     "functions": "Creative Development, Photodesign",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "CLIPSE_FLOGGNAW",
     "title": "Floggnaw",
     "subject": "Clipse",
     "functions": "Set Design, Creative Development, Photography",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "EEMCD-3",
     "title": "Magic Happens When You Dunk",
     "subject": "McDonalds x Eric Emanuel",
     "functions": "Creative Development, Director, Photodesign, Post Production",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "MarcJacobsKids_-13",
     "title": "Kids Take The Big City",
     "subject": "Marc Jacobs",
     "functions": "Production, Creative Development, Photography, Post Production",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "ADIDASXMIDWEST_KIDS",
     "title": "Midwest Kids",
     "subject": "Adidas x Midwest Kids",
     "functions": "Creative Development, Director, Photography",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "LULU_DISNEY",
     "title": "Happily Ever After",
     "subject": "Lululemon x Disney",
     "functions": "Production, Creative Development, Photodesign",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "SheckWesMUDBOY-6",
     "title": "Mudboy",
     "subject": "Sheck Wes",
     "functions": "Creative, Photography",
-    "year": "2018"
+    "year": "2018",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "AMINE_NEW_BALANCE",
     "title": "Benson Tech",
     "subject": "Amine for New Balance",
     "functions": "Production, Creative Development, Photodesign, Post Production",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "JELEELYEAAAA-9",
     "title": "Jeleel!",
     "subject": "Jeleel for Paper Magazine",
     "functions": "Production, Creative Development, Photodesign, Post Production",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "BeatsCampaign_-17",
     "title": "Feel the Beats",
     "subject": "Beats by Dre",
     "functions": "Creative Development, Casting, Director, Photography, Post Production",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "FATHER_STEVE_ICECREAM",
     "title": "Steven Savoca Mice",
     "subject": "Steven Savoca for Icecream",
     "functions": "Production, Creative Development, Photodesign, Post Production",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "Yeat2093-1",
     "title": "2093",
     "subject": "Yeat",
     "functions": "Creative Development, Photodesign, Post Production",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "JALEN_GREEN_ADIDAS",
     "title": "Jalen Green",
     "subject": "Jalen Green for Adidas",
     "functions": "Creative Development, Director, Photography",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "NEBRASKATIMBERLAND-14",
     "title": "Nebraska",
     "subject": "Vans x Timberland",
     "functions": "Creative Development, Photography, Post Production",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "khaled-11",
     "title": "DJ Khaled",
     "subject": "DJ Khaled for Jordan",
     "functions": "Creative Development, Photography, Post Production",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "NIKE_DUNK",
     "title": "True To Your Crew",
     "subject": "Nike Dunk",
     "functions": "Creative Development, Photography",
-    "year": "2021"
+    "year": "2021",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "VenedaCarterIsabella-9",
     "title": "Isabella Carr",
     "subject": "Isabella Carr for Veneda Carter",
     "functions": "Production, Creative Development, Photodesign, Post Production",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "VC_FOR_VC",
     "title": "Veneda Carter",
     "subject": "Veneda Carter for Veneda Carter",
     "functions": "Production, Creative Development, Photodesign, Post Production",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "ASSPIZZA_BACKYARD",
     "title": "Austin's Backyard",
     "subject": "Asspizza",
     "functions": "Photography",
-    "year": "2018"
+    "year": "2018",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "MURAKAMISlide_-3",
     "title": "Ohana Full Bloom",
     "subject": "Takashi Murakami",
     "functions": "Production, Creative Development, Photodesign, Post Production",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "ZEXinthestu-7",
     "title": "Zex at the Studio",
     "subject": "Zexor",
     "functions": "Photography",
-    "year": "2018"
+    "year": "2018",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "EE_MIDNIGHT_MADNESS",
     "title": "Midnight Madness",
     "subject": "Eric Emanuel for Adidas",
     "functions": "Creative Development, Director, Photography",
-    "year": "2021"
+    "year": "2021",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "HELMUT_LANG",
     "title": "Helmut Lang Community",
     "subject": "Helmut Lang",
     "functions": "Creative Development, Photography",
-    "year": "2019"
+    "year": "2019",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "KodakBlack_-9",
     "title": "Kodak Black for Asspizza",
     "subject": "Asspizza x Robin Jeans",
     "functions": "Photography",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "ASAP_ROCKY_FOR_PRADA",
     "title": "Asap Rocky for Prada",
     "subject": "Prada",
     "functions": "Photography",
-    "year": "2019"
+    "year": "2019",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "EE_GATORADE",
     "title": "Is It In You?",
     "subject": "Eric Emanuel for Gatorade",
     "functions": "Director, Photography",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "TONY_EFFE",
     "title": "Icon",
     "subject": "Tony Effe",
     "functions": "Creative, Photography, Post Production",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "AMINE_NEW_BALANCE_YB",
     "title": "Mooz 710",
     "subject": "Amine for New Balance",
     "functions": "Photography, Post Production",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "TURN_THAT_SHIT_OFF",
     "title": "Turn That Shit Off",
     "subject": "Spaghetti Boys",
     "functions": "Photography",
-    "year": "2017"
+    "year": "2017",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "LIL_TRACY_FOR_OFFICE",
     "title": "Lil Tracy",
     "subject": "Lil Tracy for Office Magazine",
     "functions": "Creative Development, Photography",
-    "year": "2020"
+    "year": "2020",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "MADHAPPYPuffer-43",
     "title": "Super Puffer",
     "subject": "Madhappy",
     "functions": "Photography",
-    "year": "2023"
+    "year": "2023",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "DON_TOLIVER_APPLE_MUSIC",
     "title": "Life of a Don",
     "subject": "Don T'Oliver for Apple Music",
     "functions": "Photography, Post Production",
-    "year": "2021"
+    "year": "2021",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
-  
   {
     "id": "YEATTXRAY-6",
     "title": "Afterlyfe",
     "subject": "Yeat",
     "functions": "Creative Development, Photodesign, Post Production",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "CloverGloves-14",
     "title": "Everyday Gloves",
     "subject": "Clover New York",
     "functions": "Production, Creative Development, Photodesign, Post Production",
-    "year": "2021-2024"
+    "year": "2021-2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "FatherSteveMouses-38",
     "title": "Steven Savoca Blind Box Toys",
     "subject": "Steven Savoca",
     "functions": "Production, Creative Development, Photography, Post Production",
-    "year": "2021-2024"
+    "year": "2021-2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "LIFE_OF_P_IERRE",
     "title": "Life of Pi'erre 5",
     "subject": "Pi'erre Bourne",
     "functions": "Creative Development, Photography, Post Production",
-    "year": "2021"
+    "year": "2021",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "F1LTHY_FOR_CLOVER",
     "title": "F1LTHY",
     "subject": "F1LTHY for Clover",
     "functions": "Photography",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "ELDER_STATESMAN",
     "title": "Mordechai Rubinstein",
     "subject": "Mordechai Rubinstein for Elder Statesmen",
     "functions": "Photography",
-    "year": "2021"
+    "year": "2021",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "GQ_REQ",
     "title": "GQ Recommended",
     "subject": "GQ Magazine",
     "functions": "Production, Creative Development, Photodesign, Post Production",
-    "year": "2022"
+    "year": "2022",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "MARC_JACOBS",
     "title": "Marc Jacobs",
     "subject": "Marc Jacobs",
     "functions": "Creative Development, Photography, Post Production",
-    "year": "2021"
+    "year": "2021",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "SOUNDCLOUD",
     "title": "First on Soundcloud",
     "subject": "Soundcloud",
     "functions": "Creative Development, Photography, Post Production",
-    "year": "2021"
+    "year": "2021",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "ASSPIZZA_FOR_SUPREME",
     "title": "Asspizza for Supreme",
     "subject": "Asspizza",
     "functions": "Photography",
-    "year": "2021"
+    "year": "2021",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "ASSPIZZA_2017",
     "title": "Asspizza 2017",
     "subject": "Asspizza",
     "functions": "Photography, Post Collage",
-    "year": "2017"
+    "year": "2017",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "AUDI",
     "title": "Run Audi Run",
     "subject": "Audi Bizar",
     "functions": "Photography",
-    "year": "2020"
+    "year": "2020",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "DONDA",
     "title": "Donda",
     "subject": "Kanye West",
     "functions": "Photography",
-    "year": "2021"
+    "year": "2021",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "CLOVER",
     "title": "Lucky Loafers",
     "subject": "Clover x Blackstock and Weber",
     "functions": "Shoe Design, Production, Creative Development, Photography, Post Production",
-    "year": "2021"
+    "year": "2021",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   },
   {
     "id": "FortniteXMetallica_-9",
     "title": "Metallica x Fortnite",
     "subject": "Fortnite",
     "functions": "Production, Creative Development, Photodesign Post Production",
-    "year": "2024"
+    "year": "2024",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
+  },
+  {
+    "id": "730GOBLIN",
+    "title": "",
+    "subject": "",
+    "functions": "",
+    "year": "",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
+  },
+  {
+    "id": "BACKBONE",
+    "title": "",
+    "subject": "",
+    "functions": "",
+    "year": "",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
+  },
+  {
+    "id": "BUCI",
+    "title": "",
+    "subject": "",
+    "functions": "",
+    "year": "",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
+  },
+  {
+    "id": "CASHAPP",
+    "title": "",
+    "subject": "",
+    "functions": "",
+    "year": "",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
+  },
+  {
+    "id": "DIEGO730",
+    "title": "",
+    "subject": "",
+    "functions": "",
+    "year": "",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
+  },
+  {
+    "id": "ILMB",
+    "title": "",
+    "subject": "",
+    "functions": "",
+    "year": "",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
+  },
+  {
+    "id": "LOXANDCHAIN",
+    "title": "",
+    "subject": "",
+    "functions": "",
+    "year": "",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
+  },
+  {
+    "id": "McDAAG",
+    "title": "",
+    "subject": "",
+    "functions": "",
+    "year": "",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
+  },
+  {
+    "id": "NIGOXNIKE",
+    "title": "",
+    "subject": "",
+    "functions": "",
+    "year": "",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
+  },
+  {
+    "id": "SLAWN",
+    "title": "",
+    "subject": "",
+    "functions": "",
+    "year": "",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
+  },
+  {
+    "id": "TONE",
+    "title": "",
+    "subject": "",
+    "functions": "",
+    "year": "",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
+  },
+  {
+    "id": "YEATXGRAILED",
+    "title": "",
+    "subject": "",
+    "functions": "",
+    "year": "",
+    "mainGalleryTitle1": "",
+    "mainGalleryTitle2": ""
   }
 ]

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -83,12 +83,27 @@ const HeroPage: React.FC = () => {
     console.log(`heroFilterState updated: ${heroFilterState}`)
     switch (heroFilterState) {
       case 'ALL':
+        console.log("-----------------")
+        console.log("-----------------")
+        console.log("All")
+        console.log("-----------------")
+        console.log("-----------------")
         setVisibleGroups(allGroups);
         break;
       case 'CLOVERPRODUCTION':
+        console.log("-----------------")
+        console.log("-----------------")
+        console.log("Clover Productions")
+        console.log("-----------------")
+        console.log("-----------------")
         setVisibleGroups(productionGroups);
         break;
       case 'VIDEO': //TODO: once we've created new set, utilize that.
+      console.log("-----------------")
+        console.log("-----------------")
+        console.log("VIDEO")
+        console.log("-----------------")
+        console.log("-----------------")
         setVisibleGroups(videoGroups);
         break;
       default:

--- a/styles/HeroGallery.module.css
+++ b/styles/HeroGallery.module.css
@@ -22,7 +22,8 @@
 .leftColumnFlex {
     display: flex;
     justify-content: flex-end;
-    flex: 1 0 auto;
+    flex: 1 1 auto;
+    position: relative;
 }
 
 .rightColumnContainer {
@@ -39,7 +40,8 @@
 .rightColumnFlex {
   display: flex;
   justify-content: flex-start;
-  flex: 1 0 auto;
+  flex: 1 1 auto;
+  position: relative;
 }
 
 .widePhotoContainer {
@@ -48,7 +50,23 @@
   margin-top: 4px;
   max-height: 80dvw; 
   margin: 0 auto;
-  @media (max-width: 768px) {
+  position: relative;
+}
+
+.widePhotoFlex {
+  display: flex;
+  justify-content: center;
+  flex: 1 1 auto;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  margin-top: 4px;
+  margin-bottom: 4px;
+
+}
+
+@media (max-width: 768px) {
+  .widePhotoContainer {
     width: 70dvw;
   }
 }
@@ -56,10 +74,13 @@
 .widePhoto {
   cursor: pointer;
   width: 100%;
-  @media (max-width: 768px) {
+  object-fit: cover;
+}
+
+@media (max-width: 768px) {
+  .widePhoto {
     max-height: 50dvw;
   }
-  object-fit: cover;
 }
 /* more specific class to add pointer cursor to non-wide photos */
 .clickablePhoto {

--- a/styles/HeroGalleryOverlay.module.css
+++ b/styles/HeroGalleryOverlay.module.css
@@ -1,0 +1,31 @@
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  color: white;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+  z-index: 1;
+  font-family: "KAMAR", sans-serif;
+  font-size: xxx-large;
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.leftColumnFlex .overlay {
+  left: auto;
+  right: 0;
+  width: auto;
+  height: auto;
+}
+.overlay:hover {
+  opacity: 1;
+}
+

--- a/types/types.ts
+++ b/types/types.ts
@@ -40,3 +40,13 @@ export interface Video {
     cloverProductionsGroups: GalleryGroup[];
     videosGroups: GalleryGroup[];
   }
+
+  export interface GalleryDescription {
+    id: string;
+    title: string;
+    subject: string;
+    functions: string;
+    year: string;
+    mainGalleryTitle1: string;
+    mainGalleryTitle2: string;
+  }


### PR DESCRIPTION
Now that main gallery titles have been added to the galleryDescriptions file, they are returned via the projectAssets API call, so we just gotta use those for the hover text.

I added a new component called AutoScaleText that accepts as args
- piece of text
- max font size (optional, default 100px)
- min font size (optional, default 12px)
- widthPercentage (optional, set to 100%): this is supposed to determine how much of parent elements width is taken up by text
- className
- parentId (optional): an id value for element of which we want to calculate width. If not passed in, grabs direct parent of the text component we're adding (in this use case, the overlay div) 

On first load this works pretty well it seems, but then when you start resizing, clicking a new filter view, things get wonky. 
I've got a bunch of debug messages going to the console in this branch, but they haven't been able to solve the issue for me.

Remaining Issues
- text width doesn't always resize correctly when window is resized manually :( 
- you cannot click thru the hover overlay to get into the gallery (this is not new to this PR)
- sporadic text width errors